### PR TITLE
Expand direct page addresses to long for lookup.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "lsp-sample",
+	"name": "snes-asm",
 	"version": "0.1.3",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4090,12 +4090,12 @@
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.2.tgz",
-			"integrity": "sha512-VVJwIA/FPl/FnVtrns0FPK6TLi/ET7n1Yo6tCrm6aG7+yAVwIGWdpTmKE+nbP8wEMMbHCkIabk63IJvfz2HNRg==",
+			"version": "3.10.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.5.tgz",
+			"integrity": "sha512-bsU8JC3B/jiYTXfpay8LHlzfEPO9RbqdpVlTuZIJDufjX/LvKARJ92eeIe0r4MUMGduGwR7b7My+HafAyH2EzQ==",
 			"requires": {
 				"vscode-jsonrpc": "^3.6.2",
-				"vscode-languageserver-types": "^3.7.2"
+				"vscode-languageserver-types": "^3.10.1"
 			}
 		},
 		"vscode-languageserver-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
 		"request-light": "^0.2.4",
 		"vscode-json-languageservice": "^3.2.0",
 		"vscode-languageserver": "^4.1.3",
+		"vscode-languageserver-protocol": "3.10.5",
 		"vscode-languageserver-types": "^3.14.0"
 	},
 	"scripts": {

--- a/server/src/overwatch.ts
+++ b/server/src/overwatch.ts
@@ -128,6 +128,7 @@ export function hoverHandler(pos: Position, doc: TextDocument): string | MarkupC
 	
 	if (match.match(ramRegExp) != null) {
 		if (match.length == 5) { match = "$7E" + match.substr(1,4); }
+		else if (match.length == 3) { match = "$7E00" + match.substr(1,2); }
 
 
 		var ramMatch = allMemory.find((r) => r.beginsAt <= parseInt("0x" + match.substr(1,6)) && r.endsAt >= parseInt("0x" + match.substr(1,6)))


### PR DESCRIPTION
This PR adds support for expanding a direct page address to a long address (prepend $7E00) for lookup on hover.

I had to force version 3.10.5 of vscode-languageserver-protocol to resolve a ts compilation error for 3 types (Color, ColorInformation, and ColorPresentation) that were also being defined in vscode-languageserver-types.